### PR TITLE
Fix outdated version reference in README, use most recent version instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To install:
 ```sh
 # Needs `--allow-read` to be able to read .proto files
 # Needs `--allow-write` to be able to write pb.ts files
-deno install --allow-read --allow-write https://deno.land/x/protod@v0.1.3/protod.ts
+deno install --allow-read --allow-write https://deno.land/x/protod/protod.ts
 
 protod gen my.proto
 ```


### PR DESCRIPTION
In fact, the listed version doesn't work on the most recent deno version. Listing the most recent version in the install guide seems sensible. :) 