### PR TITLE
Fix incorrect outfile type

### DIFF
--- a/protod.ts
+++ b/protod.ts
@@ -17,8 +17,8 @@ const command = (args.shift() || "") as keyof typeof commands;
 const commands = {
   async gen(opts: (string | number)[]) {
     const { outfile, _: args } = parse(opts.map(String), {
-      string: [],
-      boolean: ["outfile"],
+      string: ["outfile"],
+      boolean: [],
       stopEarly: true,
       alias: {
         "o": "outfile",


### PR DESCRIPTION
The filename is a string, the current setup throws an error when writing 